### PR TITLE
kube-controller-manager enable root-ca-cert-publisher controller

### DIFF
--- a/charts/garden-kube-apiserver/templates/deployment-kube-apiserver.yaml
+++ b/charts/garden-kube-apiserver/templates/deployment-kube-apiserver.yaml
@@ -188,7 +188,7 @@ spec:
         - /usr/local/bin/kube-controller-manager
         - --cluster-signing-cert-file=/srv/kubernetes/ca/ca.crt
         - --cluster-signing-key-file=/srv/kubernetes/ca/ca.key
-        - --controllers=namespace,serviceaccount,serviceaccount-token,clusterrole-aggregation,garbagecollector,csrapproving,csrcleaner,csrsigning,bootstrapsigner,tokencleaner,resourcequota
+        - --controllers=namespace,serviceaccount,serviceaccount-token,clusterrole-aggregation,garbagecollector,csrapproving,csrcleaner,csrsigning,bootstrapsigner,tokencleaner,resourcequota,root-ca-cert-publisher
         - --authorization-kubeconfig=/srv/kubernetes/controller-manager/kubeconfig
         - --authentication-kubeconfig=/srv/kubernetes/controller-manager/kubeconfig
         - --kubeconfig=/srv/kubernetes/controller-manager/kubeconfig


### PR DESCRIPTION
With the right alias this time